### PR TITLE
Run coverage on pull request, not on push

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,48 @@
+name: Coverage
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          default: true
+
+      - name: Restore cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: '--all-features --run-types Doctests,Tests --forward'
+          timeout: 120
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@239febf655bba88b16ff5dea1d3135ea8663a1f9
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: cobertura.xml
+          retention-days: 30
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,41 +82,6 @@ jobs:
       - name: Check links
         run: cargo rustdoc --all-features -- -D warnings
 
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          default: true
-
-      - name: Restore cache
-        uses: Swatinem/rust-cache@v1
-
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: '--all-features --run-types Doctests,Tests --forward'
-          timeout: 120
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@239febf655bba88b16ff5dea1d3135ea8663a1f9
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
-        with:
-          name: code-coverage-report
-          path: cobertura.xml
-          retention-days: 30
-
   clippy:
     name: Clippy lints
     runs-on: ubuntu-latest


### PR DESCRIPTION
Then the report ends up in the PR and it makes no sense to do them on
each commit anyway.