### PR TITLE
Update signal-hook to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ travis-ci = { repository = "vorner/reopen" }
 
 [dependencies]
 libc = { version = "~0.2", optional = true }
-signal-hook = { version = "~0.2", optional = true, default-features = false }
+signal-hook = { version = "~0.3", optional = true, default-features = false }
 
 [build-dependencies]
 autocfg = "~1"

--- a/examples/reopen_log.rs
+++ b/examples/reopen_log.rs
@@ -29,9 +29,9 @@ use std::time::Duration;
 use reopen::Reopen;
 
 #[cfg(windows)] // Windows has a very limited set of signals, but make it compile at least :-(
-use signal_hook::SIGINT as SIGHUP;
+use signal_hook::consts::SIGINT as SIGHUP;
 #[cfg(not(windows))]
-use signal_hook::SIGHUP;
+use signal_hook::consts::SIGHUP;
 
 /// Keeps writing into the given file (or, `Write`), one line per second.
 fn log_forever<W: Write>(mut w: W) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! fn main() -> Result<(), Error> {
 //!     let file = Reopen::new(Box::new(&open))?;
 //! # #[cfg(all(feature = "signals", not(windows)))]
-//!     file.handle().register_signal(signal_hook::SIGHUP)?;
+//!     file.handle().register_signal(signal_hook::consts::SIGHUP)?;
 //!     simple_logging::log_to(file, log::LevelFilter::Debug);
 //!     info!("Hey, it's logging");
 //!     Ok(())


### PR DESCRIPTION
It should be more or less possible to support both 0.2 and 0.3, but keeping parallel builds is hard to ensure no breakage, it's easier to just support the latest version.

This way crates that use both `reopen` and `signal-hook` could build only a single version of `signal-hook`.